### PR TITLE
Initial support for LoadBalancer

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -32,3 +32,10 @@ To get the api status:
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
     rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} api status
+
+{{- if .Values.loadBalancer.enabled }}
+
+Or from outside the cluster:
+
+  rpk --brokers={{ include "redpanda.fullname" . }}-0.{{ template "redpanda.kafka.external.domain" $ }}:{{ template "redpanda.kafka.external.advertise.port" $ }} api status
+{{- end }}

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -95,6 +95,28 @@ Generate configuration needed for rpk
 {{- (first .Values.config.redpanda.kafka_api).port -}}
 {{- end -}}
 
+{{- define "redpanda.kafka.external.domain" -}}
+{{- printf "%s." (.Values.loadBalancer.parentZone | trimSuffix ".")  -}}
+{{- end }}
+
+{{- define "redpanda.kafka.external.advertise.address" -}}
+{{- $host := "$(SERVICE_NAME)" -}}
+{{- $domain := include "redpanda.kafka.external.domain" . -}}
+{{- printf "%s.%s" $host $domain -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.external.advertise.port" -}}
+{{- .Values.loadBalancer.port -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.external.listen.address" -}}
+{{- "$(POD_IP)" -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.external.listen.port" -}}
+{{- add1 (first .Values.config.redpanda.kafka_api).port -}}
+{{- end -}}
+
 {{- define "redpanda.rpc.advertise.address" -}}
 {{- $host := "$(SERVICE_NAME)" -}}
 {{- $domain := include "redpanda.internal.domain" . -}}

--- a/redpanda/templates/service.loadbalancer.yaml
+++ b/redpanda/templates/service.loadbalancer.yaml
@@ -1,0 +1,54 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- if .Values.loadBalancer.enabled }}
+{{- range untilStep 0 (.Values.statefulset.replicas|int) 1 }}
+# This service is to expose a pod in the statefulset with a loadbalancer.
+# Includes integration with https://github.com/kubernetes-sigs/external-dns
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "redpanda.fullname" $ }}-{{ . }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" $ }}
+    app.kubernetes.io/name: {{ template "redpanda.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" $ }}
+  {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ template "redpanda.fullname" $ }}-{{ . }}.{{$.Values.loadBalancer.parentZone}}
+    {{- range $key, $value := $.Values.loadBalancer.annotations}}
+    {{$key}}: {{$value}}
+    {{- end }}
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - name: kafka
+      protocol: TCP
+      port: {{ $.Values.loadBalancer.port }}
+      targetPort: {{ template "redpanda.kafka.external.listen.port" $ }}
+  selector:
+    app.kubernetes.io/name: {{ template "redpanda.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    statefulset.kubernetes.io/pod-name: {{ template "redpanda.fullname" $ }}-{{ . }}
+  type: LoadBalancer
+---
+{{- end }}
+{{- end }}

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -104,6 +104,10 @@ spec:
               --kafka-addr=internal://{{ template "redpanda.kafka.internal.listen.address" . }}:{{ template "redpanda.kafka.internal.listen.port" . }}
               --advertise-rpc-addr={{ template "redpanda.rpc.advertise.address" . }}:{{ template "redpanda.rpc.advertise.port" . }}
               --rpc-addr={{ template "redpanda.rpc.listen.address" . }}:{{ template "redpanda.rpc.listen.port" . }}
+              {{- if .Values.loadBalancer.enabled }}
+              --advertise-kafka-addr=external://{{ template "redpanda.kafka.external.advertise.address" . }}:{{ template "redpanda.kafka.external.advertise.port" . }}
+              --kafka-addr=external://{{ template "redpanda.kafka.external.listen.address" . }}:{{ template "redpanda.kafka.external.listen.port" . }}
+              {{- end }}
               --
               --default-log-level={{ .Values.config.seastar.default_log_level }}
           ports:
@@ -111,6 +115,10 @@ spec:
               name: admin
             - containerPort: {{ template "redpanda.kafka.internal.listen.port" . }}
               name: kafka
+           {{- if .Values.loadBalancer.enabled }}
+            - containerPort: {{ template "redpanda.kafka.external.listen.port" . }}
+              name: kafka-external
+           {{- end }}
             - containerPort: {{ template "redpanda.rpc.listen.port" $ }}
               name: rpc
           volumeMounts:

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -215,3 +215,17 @@ storage:
     labels: {}
     # Additional annotations to apply to the created PersistentVolumeClaims.
     annotations: {}
+
+loadBalancer:
+  enabled: false
+  # The parent zone for DNS entries.
+  # This must be unique for each installation.
+  # See https://github.com/kubernetes-sigs/external-dns
+  parentZone: my-project.namespace.example.com.
+  # Additional annotations to apply to the created LoadBalancer services.
+  annotations: {}
+    # For example:
+    # cloud.google.com/load-balancer-type: "Internal"
+    # service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  # External port to listen on
+  port: 9092


### PR DESCRIPTION
## Initial support for exposing statefulset externally via a LoadBalancer

Fixes #15 

E.g.:
`helm template--create-namespace --namespace redpanda redpanda . --set loadBalancer.enabled=true --set loadBalancer.parentZone=my-project.namespace.example.com.`

Includes integration with: https://github.com/kubernetes-sigs/external-dns

Signed-off-by: Ben Pope <ben@vectorized.io>