### PR TITLE
Support release names that are not "redpanda"

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -19,16 +19,16 @@ Congratulations on installing {{ .Chart.Name }}!
 
 The pods will rollout in a few seconds. To check the status:
 
-  kubectl -n {{ .Release.Namespace }} rollout status -w statefulset/redpanda
+  kubectl -n {{ .Release.Namespace }} rollout status -w statefulset/{{ template "redpanda.fullname" . }}
 
 Try some sample commands, like creating a topic called topic1:
 
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.name" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api topic create topic1
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api topic create topic1
 
 To get the api status:
  
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.name" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api status
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api status

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -25,18 +25,12 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "redpanda.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
         {{- range untilStep 0 (.Values.statefulset.replicas|int) 1 }}
         - node_id: {{ . }}
           host:
-            address: {{ template "redpanda.name" $envAll }}-{{ . }}.{{ template "redpanda.name" $envAll }}.{{ $envAll.Release.Namespace }}.svc.{{ $envAll.Values.clusterDomain }}
+            address: {{ template "redpanda.fullname" $envAll }}-{{ . }}.{{ template "redpanda.fullname" $envAll }}.{{ $envAll.Release.Namespace }}.svc.{{ $envAll.Values.clusterDomain }}
             port: {{ $envAll.Values.config.redpanda.rpc_server.port }}
         {{- end }}
     rpk:

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - >
               CONFIG=/etc/redpanda/redpanda.yaml;
               NODE_ID=${HOSTNAME##*-};
-              SERVICE_NAME={{ template "redpanda.name" . }}-$NODE_ID.{{ template "redpanda.name" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }};
+              SERVICE_NAME={{ template "redpanda.fullname" . }}-$NODE_ID.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }};
               cp /tmp/base-config/redpanda.yaml $CONFIG;
               rpk --config $CONFIG config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then


### PR DESCRIPTION
If you specified a release name like "my-redpanda" the cluster would not
form as the dns name of the instances was not "redpanda-0" any longer
but was "my-redpanda-0".