### PR TITLE
Fix the github action definition

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,7 +21,7 @@ on:
       - main
   pull_request:
     branches:
-      - *
+      - '**'
 jobs:
   lint-test:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redpanda Helm Chart
 
-![Lint and Test Charts](https://github.com/vectorizedio/helm-charts/workflows/Lint%20and%20Test%20Charts/badge.svg)
+![Lint and Test Charts](https://github.com/vectorizedio/helm-charts/workflows/.github/workflows/lint-test.yml/badge.svg)
 
 ***Status: Early Access***
 


### PR DESCRIPTION
The `*` is special character in YAML, so that it needs to be enclosed.

Double asterisk provide wider filter for pull request events.

[Reference](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)