### PR TITLE
Update helm chart

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -25,10 +25,10 @@ Try some sample commands, like creating a topic called topic1:
 
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api topic create topic1
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} api topic create topic1
 
 To get the api status:
  
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ .Values.config.redpanda.kafka_api.port }} api status
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} api status

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -66,3 +66,50 @@ Strip out the suffixes on memory to pass to Redpanda
 {{- regexReplaceAll "(\\d+)(\\w?)i?" $string "${1}${2}" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate configuration needed for rpk
+*/}}
+{{- define "redpanda.internal.domain" -}}
+{{- $service := include "redpanda.fullname" . -}}
+{{- $ns := .Release.Namespace -}}
+{{- $domain := .Values.clusterDomain | trimSuffix "." -}}
+{{- printf "%s.%s.svc.%s." $service $ns $domain -}}
+{{- end }}
+
+{{- define "redpanda.kafka.internal.advertise.address" -}}
+{{- $host := "$(SERVICE_NAME)" -}}
+{{- $domain := include "redpanda.internal.domain" . -}}
+{{- printf "%s.%s" $host $domain -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.internal.advertise.port" -}}
+{{- (first .Values.config.redpanda.kafka_api).port -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.internal.listen.address" -}}
+{{- "$(POD_IP)" -}}
+{{- end -}}
+
+{{- define "redpanda.kafka.internal.listen.port" -}}
+{{- (first .Values.config.redpanda.kafka_api).port -}}
+{{- end -}}
+
+{{- define "redpanda.rpc.advertise.address" -}}
+{{- $host := "$(SERVICE_NAME)" -}}
+{{- $domain := include "redpanda.internal.domain" . -}}
+{{- printf "%s.%s" $host $domain -}}
+{{- end -}}
+
+{{- define "redpanda.rpc.advertise.port" -}}
+{{- .Values.config.redpanda.rpc_server.port -}}
+{{- end -}}
+
+{{- define "redpanda.rpc.listen.address" -}}
+{{- "$(POD_IP)" -}}
+{{- end -}}
+
+{{- define "redpanda.rpc.listen.port" -}}
+{{- .Values.config.redpanda.rpc_server.port -}}
+{{- end -}}
+

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -37,12 +37,10 @@ data:
     redpanda:
 {{ toYaml .Values.config.redpanda | indent 6 }}
       seed_servers:
-        {{- $envAll := . }}
         {{- range untilStep 0 (.Values.statefulset.replicas|int) 1 }}
-        - node_id: {{ . }}
-          host:
-            address: {{ template "redpanda.fullname" $envAll }}-{{ . }}.{{ template "redpanda.fullname" $envAll }}.{{ $envAll.Release.Namespace }}.svc.{{ $envAll.Values.clusterDomain }}
-            port: {{ $envAll.Values.config.redpanda.rpc_server.port }}
+        - host:
+            address: "{{ template "redpanda.fullname" $ }}-{{ . }}.{{ template "redpanda.internal.domain" $ }}"
+            port: {{ template "redpanda.rpc.advertise.port" $ }}
         {{- end }}
     rpk:
 {{ toYaml .Values.config.rpk | indent 6 }}

--- a/redpanda/templates/service.bootstrap.yaml
+++ b/redpanda/templates/service.bootstrap.yaml
@@ -37,8 +37,8 @@ spec:
   ports:
     - name: kafka-tcp
       protocol: TCP
-      port: {{ .Values.config.redpanda.kafka_api.port }}
-      targetPort: {{ .Values.config.redpanda.kafka_api.port }}
+      port: {{ template "redpanda.kafka.internal.advertise.port" $ }}
+      targetPort: {{ template "redpanda.kafka.internal.advertise.port" $ }}
   selector:
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/redpanda/templates/service.discovery.yaml
+++ b/redpanda/templates/service.discovery.yaml
@@ -38,8 +38,8 @@ spec:
   ports:
     - name: kafka-tcp
       protocol: TCP
-      port: {{ .Values.config.redpanda.kafka_api.port }}
-      targetPort: {{ .Values.config.redpanda.kafka_api.port }}
+      port: {{ template "redpanda.kafka.internal.advertise.port" $ }}
+      targetPort: {{ template "redpanda.kafka.internal.advertise.port" $ }}
   selector:
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -53,24 +53,27 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      # TODO:
+      # * Figure out what to do about node_id / seeds here - the operator will fix this separately
+      # * Once that's done, this initContainer can be removed
       initContainers:
         - name: {{ template "redpanda.name" . }}-configurator
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           command: ["/bin/sh", "-c"]
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           args:
             - >
               CONFIG=/etc/redpanda/redpanda.yaml;
-              NODE_ID=${HOSTNAME##*-};
-              SERVICE_NAME={{ template "redpanda.fullname" . }}-$NODE_ID.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }};
-              cp /tmp/base-config/redpanda.yaml $CONFIG;
-              rpk --config $CONFIG config set redpanda.node_id $NODE_ID;
+              NODE_ID=${SERVICE_NAME##*-};
+              cp /tmp/base-config/redpanda.yaml "$CONFIG";
+              rpk --config "$CONFIG" config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then
-                rpk --config $CONFIG config set redpanda.seed_servers '[]' --format yaml;
+                rpk --config "$CONFIG" config set redpanda.seed_servers '[]' --format yaml;
               fi;
-              rpk --config $CONFIG config set redpanda.advertised_rpc_api.address $SERVICE_NAME;
-              rpk --config $CONFIG config set redpanda.advertised_rpc_api.port {{ .Values.config.redpanda.rpc_server.port }};
-              rpk --config $CONFIG config set redpanda.advertised_kafka_api.address $SERVICE_NAME;
-              rpk --config $CONFIG config set redpanda.advertised_kafka_api.port  {{ .Values.config.redpanda.kafka_api.port }};
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /tmp/base-config 
@@ -81,21 +84,34 @@ spec:
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - >
-              --check=false
-              --smp {{ .Values.statefulset.resources.limits.cpu }}
-              --memory {{ template "redpanda.parseMemory" . }}
+              redpanda
               start
+              --smp={{ .Values.statefulset.resources.limits.cpu }}
+              --memory={{ template "redpanda.parseMemory" . }}
+              --reserve-memory=0M
+              --advertise-kafka-addr=internal://{{ template "redpanda.kafka.internal.advertise.address" . }}:{{ template "redpanda.kafka.internal.advertise.port" . }}
+              --kafka-addr=internal://{{ template "redpanda.kafka.internal.listen.address" . }}:{{ template "redpanda.kafka.internal.listen.port" . }}
+              --advertise-rpc-addr={{ template "redpanda.rpc.advertise.address" . }}:{{ template "redpanda.rpc.advertise.port" . }}
+              --rpc-addr={{ template "redpanda.rpc.listen.address" . }}:{{ template "redpanda.rpc.listen.port" . }}
               --
               --default-log-level={{ .Values.config.seastar.default_log_level }}
-              --reserve-memory 0M
           ports:
             - containerPort: {{ .Values.config.redpanda.admin.port }}
               name: admin
-            - containerPort: {{ .Values.config.redpanda.kafka_api.port }}
+            - containerPort: {{ template "redpanda.kafka.internal.listen.port" . }}
               name: kafka
-            - containerPort: {{ .Values.config.redpanda.rpc_server.port }}
+            - containerPort: {{ template "redpanda.rpc.listen.port" $ }}
               name: rpc
           volumeMounts:
             - name: datadir

--- a/redpanda/templates/tests/test-api-status.yaml
+++ b/redpanda/templates/tests/test-api-status.yaml
@@ -37,7 +37,7 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ .Values.image.tag }} 
-      args: ["api", "status", "--brokers", "{{ include "redpanda.fullname" . }}:{{ .Values.config.redpanda.kafka_api.port }}"]
+      args: ["api", "status", "--brokers", "{{ include "redpanda.fullname" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"]
       volumeMounts:
         - name: {{ template "redpanda.fullname" . }}
           mountPath: /tmp/base-config 

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -49,11 +49,17 @@ config:
       #
       # Metrics are served off of this port at /metrics.
       port: 9644
+
+    # Kafka API listeners
+    # The first entry is used to set up the headless service.
+    # Other entries are ignored.
     kafka_api:
-      # The port for the Kafka API.
-      port: 9092
+      - name: internal
+        address: $(POD_IP)
+        port: 9092
+
+    # rpc server listener
     rpc_server:
-      # The port for the internal RPC server.
       port: 33145
 
   rpk:


### PR DESCRIPTION
Depends on https://github.com/vectorizedio/redpanda/pull/556

* Template listener addresses and ports
* Remove `node-id` from `seeds`
* Use named address for `kafka-api`
* Use `rpk redpanda start` instead of `rpk start`
* Move configuration from `rpk config set` to `rpk redpanda start`

Signed-off-by: Ben Pope <ben@vectorized.io>