### PR TITLE
Update testing dependencies

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,7 +21,7 @@ on:
       - main
   pull_request:
     branches:
-      - '**'
+      - "**"
 jobs:
   lint-test:
     runs-on: ubuntu-20.04
@@ -34,20 +34,18 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.1
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
+          version: v3.5.2
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.1
 
       - name: Run chart-testing (lint)
         run: ct lint --config redpanda/ci/ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
 
       - name: Run chart-testing (install)
         run: ct install --config redpanda/ci/ct.yaml

--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v2
 name: redpanda
 description: Redpanda is the real-time engine for modern apps.
 type: application
-version: 0.1.0
+version: 1.0.4
 appVersion: latest
 sources:
 - https://github.com/vectorizedio/helm-charts


### PR DESCRIPTION
* setup-helm: v3.4.1 -> v3.5.2
* setup-python: Removed, since 3.8 is the default on ubuntu 20.04
* chart-testing: v3.3.0 -> v3.3.1
* kind-action: v1.0.0 -> v1.1.0 (K8s 1.8 -> K8s 1.9)

Signed-off-by: Ben Pope <ben@vectorized.io>