### PR TITLE
Update sample commands to use current RPK commands

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -25,10 +25,10 @@ Try some sample commands, like creating a topic called topic1:
 
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} api topic create topic1
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} topic create topic1
 
 To get the api status:
  
   kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never \
     --image {{ .Values.image.repository }}:{{ .Values.image.tag }} \
-    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} api status
+    rpk -- --brokers={{ include "redpanda.fullname" . }}-bootstrap:{{ template "redpanda.kafka.internal.advertise.port" $ }} cluster info


### PR DESCRIPTION
While going through the quick start kubernetes docs, I spawn a cluster using helm. The message I got after spawning the cluster suggested to run a few sample commands that were using deprecated apis. This PR updates the docs so that it shows current apis.